### PR TITLE
fix: change operand list Run() signature to include package name argument

### DIFF
--- a/internal/cmd/operator_list_operands.go
+++ b/internal/cmd/operator_list_operands.go
@@ -42,8 +42,6 @@ Operand kinds are determined from the owned CustomResourceDefinitions listed in
 the operator's ClusterServiceVersion.`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			l.PackageName = args[0]
-
 			writeOutput := func(io.Writer, *unstructured.UnstructuredList) error { panic("writeOutput was not set") }
 			switch output {
 			case "json":
@@ -56,7 +54,7 @@ the operator's ClusterServiceVersion.`,
 				log.Fatalf("invalid value for flag output %q, expected one of %s", output, strings.Join(validOutputs, "|"))
 			}
 
-			operands, err := l.Run(cmd.Context())
+			operands, err := l.Run(cmd.Context(), args[0])
 			if err != nil {
 				log.Fatalf("list operands: %v", err)
 			}

--- a/pkg/action/operator_list_operands.go
+++ b/pkg/action/operator_list_operands.go
@@ -16,8 +16,7 @@ import (
 
 // OperatorListOperands knows how to find and list custom resources given a package name and namespace.
 type OperatorListOperands struct {
-	config      *Configuration
-	PackageName string
+	config *Configuration
 }
 
 func NewOperatorListOperands(cfg *Configuration) *OperatorListOperands {
@@ -26,9 +25,9 @@ func NewOperatorListOperands(cfg *Configuration) *OperatorListOperands {
 	}
 }
 
-func (o *OperatorListOperands) Run(ctx context.Context) (*unstructured.UnstructuredList, error) {
+func (o *OperatorListOperands) Run(ctx context.Context, packageName string) (*unstructured.UnstructuredList, error) {
 	opKey := types.NamespacedName{
-		Name: fmt.Sprintf("%s.%s", o.PackageName, o.config.Namespace),
+		Name: fmt.Sprintf("%s.%s", packageName, o.config.Namespace),
 	}
 
 	result, err := o.listAll(ctx, opKey)


### PR DESCRIPTION
Signed-off-by: Daniel Sover <dsover@redhat.com>

Makes the operand list library more ergonomic and similar to Helm. 
https://github.com/helm/helm/blob/a499b4b179307c267bdf3ec49b880e3dbd2a5591/pkg/action/install.go#L173