### PR TITLE
fix: operator uninstall improvements

### DIFF
--- a/internal/cmd/operator_uninstall.go
+++ b/internal/cmd/operator_uninstall.go
@@ -34,6 +34,9 @@ uninstall without deleting anything.
 The "ignore" strategy keeps the operands on cluster and deletes the subscription and the operator.
 The "delete" strategy deletes the subscription, operands, and after they have finished finalizing, the operator itself.
 
+To see which operands are on-cluster and would potentially be removed during uninstall, use the kubectl operator 
+list-operands <operator> command.
+
 Setting --delete-operator-groups to true will delete the operatorgroup in the provided namespace if no other active 
 subscriptions are currently in that namespace, after removing the operator. The subscription and operatorgroup will be 
 removed even if the operator is not found.`,

--- a/internal/pkg/action/operator_uninstall.go
+++ b/internal/pkg/action/operator_uninstall.go
@@ -208,6 +208,7 @@ func (u *OperatorUninstall) deleteCSVRelatedResources(ctx context.Context, csv *
 			break
 		}
 		for _, op := range operands.Items {
+			op := op
 			u.Logf("%s %q orphaned", strings.ToLower(op.GetKind()), prettyPrint(&op))
 		}
 	case operand.Delete:
@@ -250,6 +251,7 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
+//nolint:interfacer // Skipped as all callers implement client.Object but linter complains about k8s.io/klog/v2.KMetadata
 func prettyPrint(op client.Object) string {
 	namespaced := op.GetNamespace() != ""
 	if namespaced {

--- a/internal/pkg/action/operator_uninstall.go
+++ b/internal/pkg/action/operator_uninstall.go
@@ -127,9 +127,9 @@ func (u *OperatorUninstall) deleteObjects(ctx context.Context, objs ...client.Ob
 		obj := obj
 		lowerKind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
 		if err := u.config.Client.Delete(ctx, obj); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete %s %q: %v", lowerKind, obj.GetName(), err)
+			return fmt.Errorf("delete %s %q: %v", lowerKind, prettyPrint(obj), err)
 		} else if err == nil {
-			u.Logf("%s %q deleted", lowerKind, obj.GetName())
+			u.Logf("%s %q deleted", lowerKind, prettyPrint(obj))
 		}
 	}
 	return waitForDeletion(ctx, u.config.Client, objs...)
@@ -208,7 +208,7 @@ func (u *OperatorUninstall) deleteCSVRelatedResources(ctx context.Context, csv *
 			break
 		}
 		for _, op := range operands.Items {
-			u.Logf("%s %q orphaned", strings.ToLower(op.GetKind()), prettyPrint(op))
+			u.Logf("%s %q orphaned", strings.ToLower(op.GetKind()), prettyPrint(&op))
 		}
 	case operand.Delete:
 		if operands == nil {
@@ -250,7 +250,7 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
-func prettyPrint(op unstructured.Unstructured) string {
+func prettyPrint(op client.Object) string {
 	namespaced := op.GetNamespace() != ""
 	if namespaced {
 		return fmt.Sprint(op.GetName() + "/" + op.GetNamespace())

--- a/pkg/action/operator_list_operands.go
+++ b/pkg/action/operator_list_operands.go
@@ -96,7 +96,7 @@ func (o *OperatorListOperands) unzip(ctx context.Context, operator *v1.Operator)
 
 	// check CSV is not in a failed state (to ensure some OLM multitenancy rules are not violated)
 	if csv.Status.Phase != v1alpha1.CSVPhaseSucceeded {
-		return nil, OperandListError{fmt.Sprintf("CSV underlying operator is not in a succeeded state: custom resource list may not be accurate")}
+		return nil, OperandListError{"CSV underlying operator is not in a succeeded state: custom resource list may not be accurate"}
 	}
 
 	return csv.Spec.CustomResourceDefinitions.Owned, nil

--- a/pkg/action/operator_list_operands_test.go
+++ b/pkg/action/operator_list_operands_test.go
@@ -2,7 +2,6 @@ package action_test
 
 import (
 	"context"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -176,6 +175,8 @@ var _ = Describe("OperatorListOperands", func() {
 		lister := action.NewOperatorListOperands(&cfg)
 		_, err := lister.Run(context.TODO(), "etcd")
 		Expect(err.Error()).To(ContainSubstring("CSV underlying operator is not in a succeeded state"))
+		_, ok := err.(action.OperandListError)
+		Expect(ok).To(BeTrue())
 	})
 
 	It("should fail if there is not exactly 1 operator group", func() {

--- a/pkg/action/operator_list_operands_test.go
+++ b/pkg/action/operator_list_operands_test.go
@@ -2,6 +2,7 @@ package action_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "github.com/operator-framework/api/pkg/operators/v1"


### PR DESCRIPTION
This PR has several commits that improve the `operator uninstall` command ahead of the next release which will contain the new operand deletion functionality.

The primary improvement is that previously uninstalling an operator that had no owned APIs or was in a bad state would fail, since the list-operands library which uninstall relies upon would return an error. However, in the context of uninstall, these errors should not be terminal, and now the uninstall can proceed even if the list operands call returns an error. This bug occurred naturally since uninstall and list-operands have slightly different purposes. 

Other fixes include handling the operand strategy cancel case properly, adding a list-operands description to the uninstall helptext, and pretty printing the object name and optionally namespace when deleting them from the cluster. 