### PR TITLE
Uninstall improvements

### DIFF
--- a/internal/cmd/operator_uninstall.go
+++ b/internal/cmd/operator_uninstall.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/operator-framework/kubectl-operator/internal/cmd/internal/log"
 	internalaction "github.com/operator-framework/kubectl-operator/internal/pkg/action"
+	"github.com/operator-framework/kubectl-operator/internal/pkg/operand"
 	"github.com/operator-framework/kubectl-operator/pkg/action"
 )
 
@@ -16,34 +19,60 @@ func newOperatorUninstallCmd(cfg *action.Configuration) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall <operator>",
 		Short: "Uninstall an operator and operands",
-		Long: `Uninstall removes the subscription, operator and optionally operands managed by the operator as well as 
-the relevant operatorgroup.
+		Long: `Uninstall removes the subscription, operator and optionally operands managed
+by the operator as well as the relevant operatorgroup.
 
-Warning: this command permanently deletes objects from the cluster. Running uninstall concurrently with other operations
-could result in undefined behavior. 
+Warning: this command permanently deletes objects from the cluster. Running
+uninstall concurrently with other operations could result in undefined behavior.
 
-The uninstall command first checks to find the subscription associated with the operator. It then 
-lists all operands found throughout the cluster for the operator
-specified if one is found. Since the scope of an operator is restricted by
-its operator group, this search will include namespace-scoped operands from the
-operator group's target namespaces and all cluster-scoped operands. 
+The uninstall command first checks to find the subscription associated with the
+operator. It then lists all operands found throughout the cluster for the
+operator specified if one is found. Since the scope of an operator is restricted
+by its operator group, this search will include namespace-scoped operands from
+the operator group's target namespaces and all cluster-scoped operands.
 
-The operand-deletion strategy is then considered if any operands are found on-cluster. One of cancel|ignore|delete. 
-By default, the strategy is "cancel", which means that if any operands are found when deleting the operator abort the 
-uninstall without deleting anything. 
-The "ignore" strategy keeps the operands on cluster and deletes the subscription and the operator.
-The "delete" strategy deletes the subscription, operands, and after they have finished finalizing, the operator itself.
+The operand-deletion strategy is then considered if any operands are found
+on-cluster. One of cancel|ignore|delete. By default, the strategy is "cancel",
+which means that if any operands are found when deleting the operator abort the
+uninstall without deleting anything. The "ignore" strategy keeps the operands on
+cluster and deletes the subscription and the operator. The "delete" strategy
+deletes the subscription, operands, and after they have finished finalizing, the
+operator itself.
 
-Setting --delete-operator-groups to true will delete the operatorgroup in the provided namespace if no other active 
-subscriptions are currently in that namespace, after removing the operator. The subscription and operatorgroup will be 
-removed even if the operator is not found.`,
+Setting --delete-operator-groups to true will delete the operatorgroup in the
+provided namespace if no other active subscriptions are currently in that
+namespace, after removing the operator. The subscription and operatorgroup will
+be removed even if the operator is not found.
+
+There are other deletion flags for removing additional objects, such as custom
+resource definitions, operator objects, and any other objects deployed alongside
+the operator (e.g. RBAC objects for the operator). These flags are:
+
+  --delete-operator
+
+      Deletes all objects associated with the operator by looking up the
+      operator object for the operator and deleting every referenced object
+      and then deleting the operator object itself. This implies the flag
+      '--operand-strategy=delete' because it is impossible to delete CRDs
+      without also deleting instances of those CRDs.
+
+  -X, --delete-all
+
+      This is a convenience flag that is effectively equivalent to the flags
+      '--delete-operator=true --delete-operator-groups=true'. This is
+      most useful to completely undo the effect of a previous run of
+      'kubectl operator install <operator> --create-operator-group'
+`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			u.Package = args[0]
 			if err := u.Run(cmd.Context()); err != nil {
+				if errors.Is(err, operand.ErrCancelStrategy) {
+					log.Fatalf("uninstall operator: %v"+"\n\n%s", err,
+						"See kubectl operator uninstall --help for more information on operand deletion strategies.")
+				}
 				log.Fatalf("uninstall operator: %v", err)
 			}
-			log.Printf("operator %q uninstalled", u.Package)
 		},
 	}
 	bindOperatorUninstallFlags(cmd.Flags(), u)
@@ -51,7 +80,9 @@ removed even if the operator is not found.`,
 }
 
 func bindOperatorUninstallFlags(fs *pflag.FlagSet, u *internalaction.OperatorUninstall) {
+	fs.BoolVarP(&u.DeleteAll, "delete-all", "X", false, "delete all objects associated with the operator, implies --delete-operator, --operand-strategy=delete, --delete-operator-groups")
+	fs.BoolVar(&u.DeleteOperator, "delete-operator", false, "delete operator object associated with the operator, --operand-strategy=delete")
 	fs.BoolVar(&u.DeleteOperatorGroups, "delete-operator-groups", false, "delete operator groups if no other operators remain")
 	fs.StringSliceVar(&u.DeleteOperatorGroupNames, "delete-operator-group-names", nil, "specific operator group names to delete (only effective with --delete-operator-groups)")
-	fs.VarP(&u.OperandStrategy, "operand-strategy", "s", "determines how to handle operands when deleting the operator, one of cancel|ignore|delete")
+	fs.VarP(&u.OperandStrategy, "operand-strategy", "s", "determines how to handle operands when deleting the operator, one of cancel|ignore|delete (default: cancel)")
 }

--- a/internal/cmd/operator_uninstall.go
+++ b/internal/cmd/operator_uninstall.go
@@ -32,7 +32,7 @@ by its operator group, this search will include namespace-scoped operands from
 the operator group's target namespaces and all cluster-scoped operands.
 
 The operand-deletion strategy is then considered if any operands are found
-on-cluster. One of cancel|ignore|delete. By default, the strategy is "cancel",
+on-cluster. One of abort|ignore|delete. By default, the strategy is "abort",
 which means that if any operands are found when deleting the operator abort the
 uninstall without deleting anything. The "ignore" strategy keeps the operands on
 cluster and deletes the subscription and the operator. The "delete" strategy
@@ -70,7 +70,7 @@ individually uninstalled.
 		Run: func(cmd *cobra.Command, args []string) {
 			u.Package = args[0]
 			if err := u.Run(cmd.Context()); err != nil {
-				if errors.Is(err, operand.ErrCancelStrategy) {
+				if errors.Is(err, operand.ErrAbortStrategy) {
 					log.Fatalf("uninstall operator: %v"+"\n\n%s", err,
 						"See kubectl operator uninstall --help for more information on operand deletion strategies.")
 				}
@@ -87,5 +87,5 @@ func bindOperatorUninstallFlags(fs *pflag.FlagSet, u *internalaction.OperatorUni
 	fs.BoolVar(&u.DeleteOperator, "delete-operator", false, "delete operator object associated with the operator, --operand-strategy=delete")
 	fs.BoolVar(&u.DeleteOperatorGroups, "delete-operator-groups", false, "delete operator groups if no other operators remain")
 	fs.StringSliceVar(&u.DeleteOperatorGroupNames, "delete-operator-group-names", nil, "specific operator group names to delete (only effective with --delete-operator-groups)")
-	fs.VarP(&u.OperandStrategy, "operand-strategy", "s", "determines how to handle operands when deleting the operator, one of cancel|ignore|delete (default: cancel)")
+	fs.VarP(&u.OperandStrategy, "operand-strategy", "s", "determines how to handle operands when deleting the operator, one of abort|ignore|delete (default: abort)")
 }

--- a/internal/cmd/operator_uninstall.go
+++ b/internal/cmd/operator_uninstall.go
@@ -59,9 +59,12 @@ the operator (e.g. RBAC objects for the operator). These flags are:
   -X, --delete-all
 
       This is a convenience flag that is effectively equivalent to the flags
-      '--delete-operator=true --delete-operator-groups=true'. This is
-      most useful to completely undo the effect of a previous run of
-      'kubectl operator install <operator> --create-operator-group'
+      '--delete-operator=true --delete-operator-groups=true'.
+
+NOTE: This command does not recursively uninstall unused dependencies. To return
+a cluster to its state prior to a 'kubectl operator install' call, each
+dependency of the operator that was installed automatically by OLM must be
+individually uninstalled.
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/internal/pkg/action/operator_uninstall.go
+++ b/internal/pkg/action/operator_uninstall.go
@@ -33,7 +33,7 @@ type OperatorUninstall struct {
 func NewOperatorUninstall(cfg *action.Configuration) *OperatorUninstall {
 	return &OperatorUninstall{
 		config:          cfg,
-		OperandStrategy: operand.Cancel,
+		OperandStrategy: operand.Abort,
 		Logf:            func(string, ...interface{}) {},
 	}
 }
@@ -266,8 +266,8 @@ func (u *OperatorUninstall) deleteOperatorGroup(ctx context.Context) error {
 
 // validStrategy validates the deletion strategy against the operands on-cluster
 func (u *OperatorUninstall) validStrategy(operands *unstructured.UnstructuredList) error {
-	if len(operands.Items) > 0 && u.OperandStrategy == operand.Cancel {
-		return operand.ErrCancelStrategy
+	if len(operands.Items) > 0 && u.OperandStrategy == operand.Abort {
+		return operand.ErrAbortStrategy
 	}
 	return nil
 }

--- a/internal/pkg/action/operator_uninstall_test.go
+++ b/internal/pkg/action/operator_uninstall_test.go
@@ -162,6 +162,7 @@ var _ = Describe("OperatorUninstall", func() {
 
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
+		uninstaller.OperandStrategy = operand.Ignore
 		err := uninstaller.Run(context.TODO())
 		Expect(err).To(BeNil())
 
@@ -173,7 +174,7 @@ var _ = Describe("OperatorUninstall", func() {
 	It("should fail due to invalid operand deletion strategy", func() {
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
-		uninstaller.OperandStrategy.Kind = "foo"
+		uninstaller.OperandStrategy = "foo"
 		err := uninstaller.Run(context.TODO())
 		Expect(err.Error()).To(ContainSubstring("unknown operand deletion strategy"))
 	})
@@ -181,15 +182,14 @@ var _ = Describe("OperatorUninstall", func() {
 	It("should error with operands on cluster when default cancel strategy is set", func() {
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
-		uninstaller.OperandStrategy.Kind = operand.Cancel
 		err := uninstaller.Run(context.TODO())
-		Expect(err.Error()).To(ContainSubstring("delete operands manually or re-run uninstall with a different operand deletion strategy"))
+		Expect(err).To(MatchError(operand.ErrCancelStrategy))
 	})
 
 	It("should ignore operands and delete sub and csv when ignore strategy is set", func() {
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
-		uninstaller.OperandStrategy.Kind = operand.Ignore
+		uninstaller.OperandStrategy = operand.Ignore
 		err := uninstaller.Run(context.TODO())
 		Expect(err).To(BeNil())
 
@@ -215,7 +215,7 @@ var _ = Describe("OperatorUninstall", func() {
 	It("should delete sub, csv, and operands when delete strategy is set", func() {
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
-		uninstaller.OperandStrategy.Kind = operand.Delete
+		uninstaller.OperandStrategy = operand.Delete
 		err := uninstaller.Run(context.TODO())
 		Expect(err).To(BeNil())
 
@@ -239,6 +239,7 @@ var _ = Describe("OperatorUninstall", func() {
 	It("should delete sub and operatorgroup when no CSV is found", func() {
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
+		uninstaller.OperandStrategy = operand.Ignore
 		uninstaller.DeleteOperatorGroups = true
 
 		sub.Status.InstalledCSV = "foo" // returns nil CSV

--- a/internal/pkg/action/operator_uninstall_test.go
+++ b/internal/pkg/action/operator_uninstall_test.go
@@ -179,11 +179,12 @@ var _ = Describe("OperatorUninstall", func() {
 		Expect(err.Error()).To(ContainSubstring("unknown operand deletion strategy"))
 	})
 
-	It("should error with operands on cluster when default cancel strategy is set", func() {
+	It("should error with operands on cluster when default abort strategy is set", func() {
 		uninstaller := internalaction.NewOperatorUninstall(&cfg)
 		uninstaller.Package = etcd
+		uninstaller.OperandStrategy = operand.Abort
 		err := uninstaller.Run(context.TODO())
-		Expect(err).To(MatchError(operand.ErrCancelStrategy))
+		Expect(err).To(MatchError(operand.ErrAbortStrategy))
 	})
 
 	It("should ignore operands and delete sub and csv when ignore strategy is set", func() {

--- a/internal/pkg/operand/strategy.go
+++ b/internal/pkg/operand/strategy.go
@@ -12,8 +12,8 @@ type DeletionStrategy string
 var _ flag.Value = new(DeletionStrategy)
 
 const (
-	// Cancel is the default deletion strategy: it will cancel the deletion operation if operands are on-cluster.
-	Cancel DeletionStrategy = "cancel"
+	// Abort is the default deletion strategy: it will abort the deletion operation if operands are on-cluster.
+	Abort DeletionStrategy = "abort"
 	// Ignore will ignore the operands when deleting the operator, in effect orphaning them.
 	Ignore DeletionStrategy = "ignore"
 	// Delete will delete the operands associated with the operator before deleting the operator, allowing finalizers to run.
@@ -31,7 +31,7 @@ func (d DeletionStrategy) String() string {
 
 func (d DeletionStrategy) Valid() error {
 	switch d {
-	case Cancel, Ignore, Delete:
+	case Abort, Ignore, Delete:
 		return nil
 	}
 	return fmt.Errorf("unknown operand deletion strategy %q", d)
@@ -41,4 +41,4 @@ func (d DeletionStrategy) Type() string {
 	return "DeletionStrategy"
 }
 
-var ErrCancelStrategy = errors.New(`operand deletion cancelled: one or more operands exist and operand strategy is "cancel"`)
+var ErrAbortStrategy = errors.New(`operand deletion aborted: one or more operands exist and operand strategy is "abort"`)

--- a/internal/pkg/operand/strategy.go
+++ b/internal/pkg/operand/strategy.go
@@ -1,54 +1,44 @@
 package operand
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 )
 
 // DeletionStrategy describes how to handle operands on-cluster when deleting the associated operator.
-type DeletionStrategy struct {
-	Kind DeletionStrategyKind
-}
+type DeletionStrategy string
 
-var _ flag.Value = &DeletionStrategy{}
-
-type DeletionStrategyKind string
+var _ flag.Value = new(DeletionStrategy)
 
 const (
 	// Cancel is the default deletion strategy: it will cancel the deletion operation if operands are on-cluster.
-	Cancel DeletionStrategyKind = "cancel"
+	Cancel DeletionStrategy = "cancel"
 	// Ignore will ignore the operands when deleting the operator, in effect orphaning them.
-	Ignore DeletionStrategyKind = "ignore"
+	Ignore DeletionStrategy = "ignore"
 	// Delete will delete the operands associated with the operator before deleting the operator, allowing finalizers to run.
-	Delete DeletionStrategyKind = "delete"
-	// None represents an invalid empty strategy
-	None DeletionStrategyKind = ""
+	Delete DeletionStrategy = "delete"
 )
 
 func (d *DeletionStrategy) Set(str string) error {
-	d.Kind = DeletionStrategyKind(str)
+	*d = DeletionStrategy(str)
 	return d.Valid()
 }
 
-func (d *DeletionStrategy) String() string {
-	if d.Kind == None {
-		d.Kind = Cancel
-	}
-	return string(d.Kind)
+func (d DeletionStrategy) String() string {
+	return string(d)
 }
 
 func (d DeletionStrategy) Valid() error {
-	switch d.Kind {
-	// set default strategy to cancel
-	case None:
-		d.Kind = Cancel
-		fallthrough
+	switch d {
 	case Cancel, Ignore, Delete:
 		return nil
 	}
-	return fmt.Errorf("unknown deletion strategy %q", d.Kind)
+	return fmt.Errorf("unknown operand deletion strategy %q", d)
 }
 
 func (d DeletionStrategy) Type() string {
 	return "DeletionStrategy"
 }
+
+var ErrCancelStrategy = errors.New(`operand deletion cancelled: one or more operands exist and operand strategy is "cancel"`)


### PR DESCRIPTION
This PR adds flags and functionality for deleting more operator-related objects
- `--delete-operator` - delete the operator object and everything it references, implies `--operand-strategy=delete`.
- `--delete-all` - basically `--delete-operator --delete-operator-groups`

It also simplifies the `operand.DeletionStrategy` type to be a string instead of a struct.

Lastly, it adds a specific error for `CancelStrategyError` to decouple the uninstall CLI from the uninstall action. This enables moving CLI-specific logging to the CLI layer.

---

We can probably debate the UX for the re-added deletion flags, but ever since we've removed `--delete-all` on the `main` branch, I've found myself rebuilding from the v0.3.0 tag so I could keep using it.

The frequency that I personally do `kubectl operator install`, run a few tests, and then do `kubectl operator uninstall -X` tells me that it is a very useful option to have, and I think that merits adding it back in, at least until we come up with an alternative that maintains a simple install, test, wipe clean type of workflow.