### PR TITLE
assets/demo: Use the eval built-in command for typed commands

### DIFF
--- a/assets/demo/demo.sh
+++ b/assets/demo/demo.sh
@@ -26,7 +26,7 @@ type() {
 	done
 	echo ""
 	sleep 0.25
-	$1
+	eval $1
 	[[ "$INTERACTIVE" == "1" ]] && read -p ""
 }
 


### PR DESCRIPTION
Use the `eval` built-in bash command to handle the typed command strings. This change should allow more complex commands that use pipe or redirect output.

Signed-off-by: timflannagan <timflannagan@gmail.com>