### PR TITLE
.github: Fix the go-apidiff action and use the correct version

### DIFF
--- a/.github/workflows/go-apidiff.yml
+++ b/.github/workflows/go-apidiff.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - uses: joelanford/go-apidiff@master
+    - uses: joelanford/go-apidiff@main


### PR DESCRIPTION
Signed-off-by: timflannagan <timflannagan@gmail.com>