### PR TITLE
Fix install mode compatibility checking

### DIFF
--- a/internal/pkg/action/operator_install.go
+++ b/internal/pkg/action/operator_install.go
@@ -89,10 +89,14 @@ func (i *OperatorInstall) possibleInstallModes(watchNamespaces []string) sets.St
 			string(v1alpha1.InstallModeTypeOwnNamespace),
 		)
 	case 1:
-		if watchNamespaces[0] == i.config.Namespace {
+		switch watchNamespaces[0] {
+		case "":
+			return sets.NewString(string(v1alpha1.InstallModeTypeAllNamespaces))
+		case i.config.Namespace:
 			return sets.NewString(string(v1alpha1.InstallModeTypeOwnNamespace))
+		default:
+			return sets.NewString(string(v1alpha1.InstallModeTypeSingleNamespace))
 		}
-		return sets.NewString(string(v1alpha1.InstallModeTypeSingleNamespace))
 	default:
 		return sets.NewString(string(v1alpha1.InstallModeTypeMultiNamespace))
 	}


### PR DESCRIPTION
When the operator group exists and has a single target namespace, there are actually still three possible supported install modes:
- When the target namespace is "", that means all namespaces
- When the target namespace == og.metadata.namespace, that means own namespace
- Otherwise, that means single namespace