### PR TITLE
New feature: list-operatorgroups 

### DIFF
--- a/assets/list-operatorgroup-test/gen-og-topology.sh
+++ b/assets/list-operatorgroup-test/gen-og-topology.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+    
+
+OUTPUTFILE="test-manifests.yaml"
+
+function createNS {
+  ns="$1"
+  cat <<EOF >> $OUTPUTFILE 
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: $ns
+---
+EOF
+}
+
+function createOG {
+  ns="$1"
+  targets="$2"
+  
+  createNS $ns
+
+cat <<EOF >> $OUTPUTFILE
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: $ns
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+EOF
+  if [ -n "$targets" ];then
+    echo "spec:">> $OUTPUTFILE
+    echo "  targetNamespaces:">> $OUTPUTFILE
+    for i in ${targets//,/ }
+    do
+        echo "  - $i" >> $OUTPUTFILE
+    done
+  fi
+  echo "---" >> $OUTPUTFILE
+
+}
+
+
+
+# 3 Levels to test
+# o[name]==NS with OG
+# o[name]s== NS with Self.
+# n[name]==NS w/o OG (operand namespace)
+#
+# Good ones....
+# oas
+# obs --> ob1
+# oc  --> oc1
+#     --> oc2
+# od --> od1 --> od11
+#            --> od12
+#    --> od2 --> od21
+#            --> od22
+# oe --> ne1
+# of --> nf1
+#    --> nf2
+# og --> og1 --> ng11
+#            --> ng12
+#    --> og2 --> ng21
+#            --> ng22
+# oh --> oh1 --> nh11
+# oh ----------> nh11
+#
+# Bad ones...
+# oaa --> oaa1
+# obb --> oaa1
+# occ --> occ1 --> occ11
+# odd --> odd1 --> odd11
+#     --> odd2 --> occ11     
+
+# Cleanup:
+# kubectl delete ns -l operator-framework.coreos.com/kubectloperator=test
+
+rm $OUTPUTFILE
+
+createOG oa oa
+
+createOG ob "ob,ob1"
+createOG ob1 ob1
+
+createOG oc "oc1,oc2"
+createOG oc1 oc1
+createOG oc2 oc2
+
+createOG od "od,od1,od2"
+createOG od1 "od1,od11,od12"
+createOG od11 od11
+createOG od12 od12
+createOG od2 "od2,od21,od22"
+createOG od21 od21
+createOG od22 od22
+
+createOG oe ne1
+createNS ne1
+
+createOG of "nf1,nf2"
+createNS nf1
+createNS nf2
+
+createOG og "og1,og2"
+createOG og1 "ng11,ng12"
+createNS ng11
+createNS ng12
+createOG og2 "ng21,ng22"
+createNS ng21
+createNS ng22
+
+createOG oh "oh1,th11"
+createOG oh1 nh11
+createNS nh11
+
+# Error/Bad Topologies
+createOG oaa oaa1
+createOG oaa1 oaa1
+createOG obb oaa1  # Intersection
+
+createOG occ occ1
+createOG occ1 occ11
+createOG occ11 occ11
+createOG odd odd1
+createOG odd1 odd11
+createOG odd2 occ11 # Intersection
+

--- a/assets/list-operatorgroup-test/test-manifests.yaml
+++ b/assets/list-operatorgroup-test/test-manifests.yaml
@@ -1,0 +1,591 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oa
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oa
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oa
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ob
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: ob
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ob
+  - ob1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ob1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: ob1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ob1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oc
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oc
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oc1
+  - oc2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oc1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oc1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oc1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oc2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oc2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oc2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od
+  - od1
+  - od2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od1
+  - od11
+  - od12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od11
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od11
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od12
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od12
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od2
+  - od21
+  - od22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od21
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od21
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od21
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od22
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od22
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oe
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oe
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ne1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ne1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: of
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: of
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - nf1
+  - nf2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: nf1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: nf2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: og
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: og
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - og1
+  - og2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: og1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: og1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ng11
+  - ng12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: og2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: og2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ng21
+  - ng22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng21
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oh
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oh
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oh1
+  - th11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oh1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oh1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - nh11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: nh11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oaa
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oaa
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oaa1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oaa1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oaa1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oaa1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: obb
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: obb
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oaa1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: occ
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: occ
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: occ1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: occ1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: occ11
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: occ11
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: odd
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: odd
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - odd1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: odd1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: odd1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - odd11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: odd2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: odd2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ11
+---

--- a/assets/operatorgroup-list-test/gen-og-topology.sh
+++ b/assets/operatorgroup-list-test/gen-og-topology.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+    
+
+OUTPUTFILE="test-manifests.yaml"
+
+function createNS {
+  ns="$1"
+  cat <<EOF >> $OUTPUTFILE 
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: $ns
+---
+EOF
+}
+
+function createOG {
+  ns="$1"
+  targets="$2"
+  
+  createNS $ns
+
+cat <<EOF >> $OUTPUTFILE
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: $ns
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+EOF
+  if [ -n "$targets" ];then
+    echo "spec:">> $OUTPUTFILE
+    echo "  targetNamespaces:">> $OUTPUTFILE
+    for i in ${targets//,/ }
+    do
+        echo "  - $i" >> $OUTPUTFILE
+    done
+  fi
+  echo "---" >> $OUTPUTFILE
+
+}
+
+
+
+# 3 Levels to test
+# o[name]==NS with OG
+# o[name]s== NS with Self.
+# n[name]==NS w/o OG (operand namespace)
+#
+# Good ones....
+# oas
+# obs --> ob1
+# oc  --> oc1
+#     --> oc2
+# od --> od1 --> od11
+#            --> od12
+#    --> od2 --> od21
+#            --> od22
+# oe --> ne1
+# of --> nf1
+#    --> nf2
+# og --> og1 --> ng11
+#            --> ng12
+#    --> og2 --> ng21
+#            --> ng22
+# oh --> oh1 --> nh11
+# oh ----------> nh11
+#
+# Bad ones...
+# oaa --> oaa1
+# obb --> oaa1
+# occ --> occ1 --> occ11
+# odd --> odd1 --> odd11
+#     --> odd2 --> occ11     
+
+# Cleanup:
+# kubectl delete ns -l operator-framework.coreos.com/kubectloperator=test
+
+rm $OUTPUTFILE
+
+createOG oa oa
+
+createOG ob "ob,ob1"
+createOG ob1 ob1
+
+createOG oc "oc1,oc2"
+createOG oc1 oc1
+createOG oc2 oc2
+
+createOG od "od,od1,od2"
+createOG od1 "od1,od11,od12"
+createOG od11 od11
+createOG od12 od12
+createOG od2 "od2,od21,od22"
+createOG od21 od21
+createOG od22 od22
+
+createOG oe ne1
+createNS ne1
+
+createOG of "nf1,nf2"
+createNS nf1
+createNS nf2
+
+createOG og "og1,og2"
+createOG og1 "ng11,ng12"
+createNS ng11
+createNS ng12
+createOG og2 "ng21,ng22"
+createNS ng21
+createNS ng22
+
+createOG oh "oh1,th11"
+createOG oh1 nh11
+createNS nh11
+
+# Error/Bad Topologies
+createOG oaa oaa1
+createOG oaa1 oaa1
+createOG obb oaa1  # Intersection
+
+createOG occ occ1
+createOG occ1 occ11
+createOG occ11 occ11
+createOG odd odd1
+createOG odd1 odd11
+createOG odd2 occ11 # Intersection
+

--- a/assets/operatorgroup-list-test/test-manifests.yaml
+++ b/assets/operatorgroup-list-test/test-manifests.yaml
@@ -1,0 +1,591 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oa
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oa
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oa
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ob
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: ob
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ob
+  - ob1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ob1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: ob1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ob1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oc
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oc
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oc1
+  - oc2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oc1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oc1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oc1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oc2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oc2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oc2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od
+  - od1
+  - od2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od1
+  - od11
+  - od12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od11
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od11
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od12
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od12
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od2
+  - od21
+  - od22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od21
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od21
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od21
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: od22
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: od22
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - od22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oe
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oe
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ne1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ne1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: of
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: of
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - nf1
+  - nf2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: nf1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: nf2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: og
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: og
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - og1
+  - og2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: og1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: og1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ng11
+  - ng12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng12
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: og2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: og2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - ng21
+  - ng22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng21
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: ng22
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oh
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oh
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oh1
+  - th11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oh1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oh1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - nh11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: nh11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oaa
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oaa
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oaa1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: oaa1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: oaa1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oaa1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: obb
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: obb
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - oaa1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: occ
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: occ
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: occ1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: occ1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: occ11
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: occ11
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: odd
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: odd
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - odd1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: odd1
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: odd1
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - odd11
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    operatorframework.io/kubectloperator: test
+  name: odd2
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: og
+  namespace: odd2
+  labels:
+    operatorframework.coreos.com/kubectloperator: test
+spec:
+  targetNamespaces:
+  - occ11
+---

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200228182428-0f16d7a0959c // indirect
 	github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deckarep/golang-set/v2 v2.1.0 // indirect
 	github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce // indirect
@@ -76,10 +77,11 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect
 	go.opencensus.io v0.22.4 // indirect
+	golang.org/x/exp v0.0.0-20221114191408-850992195362 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
+github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
@@ -931,6 +933,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
+golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1101,6 +1105,8 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/internal/cmd/operatorgroup_list.go
+++ b/internal/cmd/operatorgroup_list.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/operator-framework/kubectl-operator/internal/cmd/internal/log"
+	internalaction "github.com/operator-framework/kubectl-operator/internal/pkg/action"
+	"github.com/operator-framework/kubectl-operator/pkg/action"
+)
+
+func newOperatorGroupListCmd(cfg *action.Configuration) *cobra.Command {
+	var allNamespaces bool
+	i := internalaction.NewOperatorGroupList(cfg)
+	//i.Logf = log.Printf
+
+	cmd := &cobra.Command{
+		Use:   "list-operatorgroups",
+		Short: "List all OperatorGroups",
+		Example: `
+#
+# Output a tabular list of OperatorGroups as Tenants:
+# 
+$ kubectl operator list-operatorgroups -A
+
+# Output a graph of OperatorGroups as Tenants in mermaid format:
+#
+$ kubectl operator list-operatorgroups -A -g
+
+#
+# Output a graph of OperatorGroups as Tenants as a SVG image:
+#
+$ kubectl operator list-operatorgroups -A -g | \
+		docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -o /data/tenants.svg
+
+# Note:  mermaid has a default maxTextSize of 30 000 characters.  To override this, generate a JSON-formatted initialization file for
+# mermaid like this (using 300 000 for the limit):
+$ cat << EOF > ./mermaid.json
+{ "maxTextSize": 300000 }
+EOF
+# and then pass the file for initialization configuration, via the '-c' option, like:
+$ kubectl operator list-operatorgroups -A -g | \
+		docker run --rm -i -v "$PWD":/data ghcr.io/mermaid-js/mermaid-cli/mermaid-cli -c /data/mermaid.json -o /data/operatorhubio-catalog.svg
+
+
+`,
+
+		Run: func(cmd *cobra.Command, args []string) {
+			if allNamespaces {
+				cfg.Namespace = v1.NamespaceAll
+			}
+
+			tenants, err := i.Run(cmd.Context())
+			if err != nil {
+				log.Fatalf("failed to list operator groups: %v", err)
+			}
+			if len(tenants) == 0 {
+				log.Printf("No Namespaces with OperatorGroups found in the current context.")
+			}
+
+			sort.SliceStable(tenants, func(i, j int) bool {
+				return strings.Compare(tenants[i].Namespace, tenants[j].Namespace) < 0
+			})
+
+			if i.ShowGraph {
+				out := createGraph(tenants)
+				for _, v := range out {
+					fmt.Print(v)
+				}
+			} else {
+				tw := tabwriter.NewWriter(os.Stdout, 3, 4, 2, ' ', 0)
+				_, _ = fmt.Fprintf(tw, "TENANT\tTYPE\tSUBTENANTS\tTARGETNAMESPACES\tPARENTTENANTS\n")
+				for _, tenant := range tenants {
+					if tenant.OperatorGroup != nil {
+						targetnss := strings.Join(tenant.OperatorGroup.Spec.TargetNamespaces, ",")
+
+						childTenants := make([]string, 0, len(tenant.ChildrenTenants))
+						for _, childTenant := range tenant.ChildrenTenants {
+							if childTenant.Namespace != tenant.Namespace {
+								childTenants = append(childTenants, childTenant.Namespace)
+							}
+						}
+						childTenantsStr := strings.Join(childTenants, ",")
+						parentTenants := make([]string, 0, len(tenant.ParentTenants))
+						for _, parentTenant := range tenant.ParentTenants {
+							parentTenants = append(parentTenants, parentTenant.Namespace)
+						}
+						parentTenantsStr := strings.Join(parentTenants, ",")
+
+						fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", tenant.Namespace, effectiveInstallMode(*tenant), childTenantsStr, targetnss, parentTenantsStr)
+					}
+				}
+				_ = tw.Flush()
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&i.ShowGraph, "graph", "g", false, "generate a graph")
+	cmd.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", false, "list operators in all namespaces")
+
+	return cmd
+}
+
+func createGraph(tenants []*internalaction.Tenant) []string {
+	out := make([]string, 0)
+	in := "  "
+
+	// Create a Mermaid graph of "Tenants"
+
+	// Header and formatting
+	out = append(out,
+		"flowchart LR\n",
+		in+"classDef tenant fill:#eFe,stroke:#000;\n",
+		in+"classDef bad fill:#f99,stroke:#000;\n",
+		in+"classDef ns fill:#fff,stroke:#000,stroke-width:1px;\n",
+		in+fmt.Sprintf("classDef im-%s fill:#eef,stroke:#000,stroke-width:2px;\n", v1alpha1.InstallModeTypeOwnNamespace),
+		in+fmt.Sprintf("classDef im-%s fill:#ddf,stroke:#000,stroke-width:2px;\n", v1alpha1.InstallModeTypeSingleNamespace),
+		in+fmt.Sprintf("classDef im-%s fill:#ccf,stroke:#000,stroke-width:2px;\n", v1alpha1.InstallModeTypeMultiNamespace),
+		"\n",
+	)
+
+	// Legend
+	out = append(out,
+		in+"subgraph Legend [Legend]\n",
+		in+"direction TB",
+		in+"LNS[Namespace]:::ns\n",
+		in+fmt.Sprintf("LOGOWN(%s):::im-%s\n", v1alpha1.InstallModeTypeOwnNamespace, v1alpha1.InstallModeTypeOwnNamespace),
+		in+fmt.Sprintf("LOGSINGLE(%s):::im-%s\n", v1alpha1.InstallModeTypeSingleNamespace, v1alpha1.InstallModeTypeSingleNamespace),
+		in+fmt.Sprintf("LOGMULTI(%s):::im-%s\n", v1alpha1.InstallModeTypeMultiNamespace, v1alpha1.InstallModeTypeMultiNamespace),
+		in+"LOGNS[Operand Namespace]:::ns\n",
+		in+"end",
+	)
+
+	// The Node in a graph
+	type Node struct {
+		Id     string                 // The node id.
+		Tenant *internalaction.Tenant // The Tenant represented by the Node
+		Class  string                 // The style class
+		Name   string                 // The display name
+		im     string                 // Effective installmode or ""
+	}
+
+	// Convert to Nodes by namespace/id name
+	nodeMap := make(map[string]Node, len(tenants))
+	for i := range tenants {
+		t := tenants[i]
+		n := Node{
+			Id:     t.Namespace,
+			Tenant: t,
+		}
+
+		// No OG means an operand namespace
+		if t.OperatorGroup == nil {
+			n.Name = "[" + n.Id + "]"
+			n.Class = "ns"
+		} else {
+			n.Name = "(" + n.Id + ")"
+			n.im = effectiveInstallMode(*t)
+			n.Class = "im-" + n.im
+		}
+
+		if len(t.ParentTenants) > 1 {
+			n.Class = "bad"
+		}
+		nodeMap[t.Namespace] = n
+	}
+
+	// Avoid cycles by recording our edges.
+	processed := mapset.NewSet[string]()
+
+	for _, node := range nodeMap {
+		level := 0
+
+		// Ignore AllNamespace mode Tenants and Namespace-only tenants
+		if node.Tenant.OperatorGroup != nil && node.im != (string)(v1alpha1.InstallModeTypeAllNamespaces) {
+
+			var writeTenant func(leftTenant *internalaction.Tenant, rtTenant *internalaction.Tenant)
+			writeTenant = func(leftTenant *internalaction.Tenant, rtTenant *internalaction.Tenant) {
+				level++
+				space := strings.Repeat(" ", level*2)
+
+				leftNode := nodeMap[leftTenant.Namespace]
+				rtNode := nodeMap[rtTenant.Namespace]
+
+				edge := leftNode.Id + ">" + rtNode.Id
+				if !processed.Contains(edge) {
+					processed.Add(edge)
+
+					out = append(out,
+						space+fmt.Sprintf("%s%s:::%s --> %s%s:::%s\n", leftNode.Id, leftNode.Name, leftNode.Class, rtNode.Id, rtNode.Name, rtNode.Class),
+					)
+
+					for j := range rtTenant.ChildrenTenants {
+						var childTenant *internalaction.Tenant = rtTenant.ChildrenTenants[j]
+						if childTenant == rtTenant {
+							// Write out self-references
+							writeTenant(rtTenant, rtTenant)
+						} else {
+							writeTenant(rtTenant, childTenant)
+						}
+					}
+				}
+				level--
+			}
+
+			// Any tenant that has no parents, is the Root of the tenant tree.
+			if len(node.Tenant.ParentTenants) == 0 {
+				// Linked Tenants will be embedded in the parent Tenant subgraph
+				out = append(out,
+					in+fmt.Sprintf("t-%s:::tenant\n", node.Id),
+					in+fmt.Sprintf("subgraph t-%s[%s]\n", node.Id, node.Id),
+					in+"direction LR\n",
+				)
+
+				for _, childTenant := range node.Tenant.ChildrenTenants {
+					writeTenant(node.Tenant, childTenant)
+				}
+
+				out = append(out,
+					in+"end\n\n",
+				)
+			}
+		}
+	}
+
+	return out
+}
+
+func effectiveInstallMode(t internalaction.Tenant) string {
+	switch len(t.OperatorGroup.Spec.TargetNamespaces) {
+	case 0:
+		return (string)(v1alpha1.InstallModeTypeAllNamespaces)
+	case 1:
+		switch t.OperatorGroup.Spec.TargetNamespaces[0] {
+		case "":
+			return (string)(v1alpha1.InstallModeTypeAllNamespaces)
+		case t.OperatorGroup.Namespace:
+			return (string)(v1alpha1.InstallModeTypeOwnNamespace)
+		default:
+			return string(v1alpha1.InstallModeTypeSingleNamespace)
+		}
+	default:
+		return string(v1alpha1.InstallModeTypeMultiNamespace)
+	}
+}

--- a/internal/cmd/operatorgroup_list.go
+++ b/internal/cmd/operatorgroup_list.go
@@ -140,7 +140,7 @@ func createGraph(tenants []*internalaction.Tenant) []string {
 
 	// The Node in a graph
 	type Node struct {
-		Id     string                 // The node id.
+		ID     string                 // The node id.
 		Tenant *internalaction.Tenant // The Tenant represented by the Node
 		Class  string                 // The style class
 		Name   string                 // The display name
@@ -152,16 +152,16 @@ func createGraph(tenants []*internalaction.Tenant) []string {
 	for i := range tenants {
 		t := tenants[i]
 		n := Node{
-			Id:     t.Namespace,
+			ID:     t.Namespace,
 			Tenant: t,
 		}
 
 		// No OG means an operand namespace
 		if t.OperatorGroup == nil {
-			n.Name = "[" + n.Id + "]"
+			n.Name = "[" + n.ID + "]"
 			n.Class = "ns"
 		} else {
-			n.Name = "(" + n.Id + ")"
+			n.Name = "(" + n.ID + ")"
 			n.im = effectiveInstallMode(*t)
 			n.Class = "im-" + n.im
 		}
@@ -189,12 +189,12 @@ func createGraph(tenants []*internalaction.Tenant) []string {
 				leftNode := nodeMap[leftTenant.Namespace]
 				rtNode := nodeMap[rtTenant.Namespace]
 
-				edge := leftNode.Id + ">" + rtNode.Id
+				edge := leftNode.ID + ">" + rtNode.ID
 				if !processed.Contains(edge) {
 					processed.Add(edge)
 
 					out = append(out,
-						space+fmt.Sprintf("%s%s:::%s --> %s%s:::%s\n", leftNode.Id, leftNode.Name, leftNode.Class, rtNode.Id, rtNode.Name, rtNode.Class),
+						space+fmt.Sprintf("%s%s:::%s --> %s%s:::%s\n", leftNode.ID, leftNode.Name, leftNode.Class, rtNode.ID, rtNode.Name, rtNode.Class),
 					)
 
 					for j := range rtTenant.ChildrenTenants {
@@ -214,8 +214,8 @@ func createGraph(tenants []*internalaction.Tenant) []string {
 			if len(node.Tenant.ParentTenants) == 0 {
 				// Linked Tenants will be embedded in the parent Tenant subgraph
 				out = append(out,
-					in+fmt.Sprintf("t-%s:::tenant\n", node.Id),
-					in+fmt.Sprintf("subgraph t-%s[%s]\n", node.Id, node.Id),
+					in+fmt.Sprintf("t-%s:::tenant\n", node.ID),
+					in+fmt.Sprintf("subgraph t-%s[%s]\n", node.ID, node.ID),
 					in+"direction LR\n",
 				)
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -63,6 +63,7 @@ operators from the installed catalogs.`,
 		newOperatorListAvailableCmd(&cfg),
 		newOperatorListOperandsCmd(&cfg),
 		newOperatorDescribeCmd(&cfg),
+		newOperatorGroupListCmd(&cfg),
 		newVersionCmd(),
 	)
 

--- a/internal/pkg/action/operator_list_available.go
+++ b/internal/pkg/action/operator_list_available.go
@@ -39,10 +39,10 @@ func (l *OperatorListAvailable) Run(ctx context.Context) ([]operator.PackageMani
 	if err := l.config.Client.List(ctx, &pms, labelSelector); err != nil {
 		return nil, err
 	}
-	pkgs := make([]operator.PackageManifest, len(pms.Items))
+	pkgs := make([]operator.PackageManifest, 0, len(pms.Items))
 	for i := range pms.Items {
 		if l.Package == "" || l.Package == pms.Items[i].GetName() {
-			pkgs[i] = operator.PackageManifest{PackageManifest: pms.Items[i]}
+			pkgs = append(pkgs, operator.PackageManifest{PackageManifest: pms.Items[i]})
 		}
 	}
 	return pkgs, nil

--- a/internal/pkg/action/operatorgroup_list.go
+++ b/internal/pkg/action/operatorgroup_list.go
@@ -37,7 +37,7 @@ func NewOperatorGroupList(cfg *action.Configuration) *OperatorGroupList {
 	}
 }
 
-// Retreive a list of Tenants that represent a Namespace with and without an OperatorGroup
+// Retrieve a list of Tenants that represent a Namespace with and without an OperatorGroup
 func (l *OperatorGroupList) Run(ctx context.Context) ([]*Tenant, error) {
 	ogs := v1.OperatorGroupList{}
 	options := client.ListOptions{Namespace: l.config.Namespace}
@@ -47,11 +47,12 @@ func (l *OperatorGroupList) Run(ctx context.Context) ([]*Tenant, error) {
 	// ObjectGroups by Namespace name.
 	ogMap := make(map[string]*v1.OperatorGroup, len(ogs.Items))
 	for _, og := range ogs.Items {
+		og := og
 		ogMap[og.Namespace] = &og
 	}
 
 	// Graph of Tenants
-	// Tenant has children, incuding (optionally) self.
+	// Tenant has children, including (optionally) self.
 	// Tenant has parents, not including self.
 	tenantMap := make(map[string]*Tenant)
 

--- a/internal/pkg/action/operatorgroup_list.go
+++ b/internal/pkg/action/operatorgroup_list.go
@@ -1,0 +1,91 @@
+package action
+
+import (
+	"context"
+
+	v1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/kubectl-operator/pkg/action"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+/**
+Plan:
+- Show the Operator Group Tenancy model by namespace
+- Show namespaces that have an OperatorGroup in them.
+- Show sub-namespaces
+- NAMESPACE, TYPE, TARGETS
+*/
+
+// A Tenant is some Namespace that may or may not have an OperatorGroup.
+// The ParentTenants and ChildrenTenants describe the relationship between this
+// Tenant namespace and how the OperatorGroup ties them together.
+type Tenant struct {
+	Namespace       string
+	OperatorGroup   *v1.OperatorGroup // The optional OperatorGroup associated with the Tenant
+	ParentTenants   []*Tenant         // Tenants that watch this tenant.
+	ChildrenTenants []*Tenant         // Tenants that this tenant watches, possibly including self.
+}
+type OperatorGroupList struct {
+	config *action.Configuration
+
+	ShowGraph bool
+}
+
+func NewOperatorGroupList(cfg *action.Configuration) *OperatorGroupList {
+	return &OperatorGroupList{
+		config: cfg,
+	}
+}
+
+// Retreive a list of Tenants that represent a Namespace with and without an OperatorGroup
+func (l *OperatorGroupList) Run(ctx context.Context) ([]*Tenant, error) {
+	ogs := v1.OperatorGroupList{}
+	options := client.ListOptions{Namespace: l.config.Namespace}
+	if err := l.config.Client.List(ctx, &ogs, &options); err != nil {
+		return nil, err
+	}
+	// ObjectGroups by Namespace name.
+	ogMap := make(map[string]*v1.OperatorGroup, len(ogs.Items))
+	for _, og := range ogs.Items {
+		ogMap[og.Namespace] = &og
+	}
+
+	// Graph of Tenants
+	// Tenant has children, incuding (optionally) self.
+	// Tenant has parents, not including self.
+	tenantMap := make(map[string]*Tenant)
+
+	// Convert each ObjectGroup to a Tenant, decorating each Tenant
+	coreTenants := make([]*Tenant, len(ogs.Items))
+	for i, og := range ogs.Items {
+		og := og
+		t := Tenant{
+			OperatorGroup: &og,
+			Namespace:     og.Namespace,
+		}
+		coreTenants[i] = &t
+		tenantMap[og.Namespace] = &t
+	}
+
+	// Process each core Tenant's ObjectGroup's target namespace, linking them up in a graph.
+	for _, t := range coreTenants {
+		for _, ns := range t.OperatorGroup.Spec.TargetNamespaces {
+			childTenant := tenantMap[ns]
+			if childTenant == nil {
+				childTenant = &Tenant{Namespace: ns}
+				tenantMap[ns] = childTenant
+			}
+			t.ChildrenTenants = append(t.ChildrenTenants, childTenant)
+
+			if childTenant.Namespace != t.Namespace {
+				// Don't add self as a parent
+				childTenant.ParentTenants = append(childTenant.ParentTenants, t)
+			}
+		}
+	}
+	tenants := make([]*Tenant, 0, len(tenantMap))
+	for _, t := range tenantMap {
+		tenants = append(tenants, t)
+	}
+	return tenants, nil
+}


### PR DESCRIPTION
This is a new feature:  `kubectl-operator list-operatorgroups`

The goal here is to:
- List out all OperatorGroup and related namespaces as Tenants
- Provide both Tabular and Mermaid support

Example output using a set of test data found in `assets/operatorgroup-list-test`:
```
$ bin/kubectl-operator list-operatorgroups -A 
TENANT                                TYPE             SUBTENANTS  TARGETNAMESPACES                      PARENTTENANTS
oa                                    OwnNamespace                 oa                                    
oaa                                   SingleNamespace  oaa1        oaa1                                  
oaa1                                  OwnNamespace                 oaa1                                  oaa,obb
ob                                    MultiNamespace   ob1         ob,ob1                                
ob1                                   OwnNamespace                 ob1                                   ob
obb                                   SingleNamespace  oaa1        oaa1                                  
oc                                    MultiNamespace   oc1,oc2     oc1,oc2                               
oc1                                   OwnNamespace                 oc1                                   oc
oc2                                   OwnNamespace                 oc2                                   oc
occ                                   SingleNamespace  occ1        occ1                                  
occ1                                  SingleNamespace  occ11       occ11                                 occ
occ11                                 OwnNamespace                 occ11                                 occ1,odd2
od                                    MultiNamespace   od1,od2     od,od1,od2                            
od1                                   MultiNamespace   od11,od12   od1,od11,od12                         od
od11                                  OwnNamespace                 od11                                  od1
od12                                  OwnNamespace                 od12                                  od1
od2                                   MultiNamespace   od21,od22   od2,od21,od22                         od
od21                                  OwnNamespace                 od21                                  od2
od22                                  OwnNamespace                 od22                                  od2
odd                                   SingleNamespace  odd1        odd1                                  
odd1                                  SingleNamespace  odd11       odd11                                 odd
odd2                                  SingleNamespace  occ11       occ11                                 
oe                                    SingleNamespace  ne1         ne1                                   
of                                    MultiNamespace   nf1,nf2     nf1,nf2                               
og                                    MultiNamespace   og1,og2     og1,og2                               
og1                                   MultiNamespace   ng11,ng12   ng11,ng12                             og
og2                                   MultiNamespace   ng21,ng22   ng21,ng22                             og
oh                                    MultiNamespace   oh1,th11    oh1,th11                              
oh1                                   SingleNamespace  nh11        nh11                                  oh
openshift-monitoring                  AllNamespaces                                                      
openshift-operator-lifecycle-manager  OwnNamespace                 openshift-operator-lifecycle-manager  
openshift-operators                   AllNamespaces   
```

`$ bin/kubectl-operator list-operatorgroups  -A -g`
```mermaid
flowchart LR
  classDef tenant fill:#eFe,stroke:#000;
  classDef bad fill:#f99,stroke:#000;
  classDef ns fill:#fff,stroke:#000,stroke-width:1px;
  classDef im-OwnNamespace fill:#eef,stroke:#000,stroke-width:2px;
  classDef im-SingleNamespace fill:#ddf,stroke:#000,stroke-width:2px;
  classDef im-MultiNamespace fill:#ccf,stroke:#000,stroke-width:2px;

  subgraph Legend [Legend]
  direction TB  LNS[Namespace]:::ns
  LOGOWN(OwnNamespace):::im-OwnNamespace
  LOGSINGLE(SingleNamespace):::im-SingleNamespace
  LOGMULTI(MultiNamespace):::im-MultiNamespace
  LOGNS[Operand Namespace]:::ns
  end  t-multicluster-engine:::tenant
  subgraph t-multicluster-engine[multicluster-engine]
  direction LR
  multicluster-engine(multicluster-engine):::im-OwnNamespace --> multicluster-engine(multicluster-engine):::im-OwnNamespace
  end

  t-oc:::tenant
  subgraph t-oc[oc]
  direction LR
  oc(oc):::im-MultiNamespace --> oc1(oc1):::im-OwnNamespace
    oc1(oc1):::im-OwnNamespace --> oc1(oc1):::im-OwnNamespace
  oc(oc):::im-MultiNamespace --> oc2(oc2):::im-OwnNamespace
    oc2(oc2):::im-OwnNamespace --> oc2(oc2):::im-OwnNamespace
  end

  t-obb:::tenant
  subgraph t-obb[obb]
  direction LR
  obb(obb):::im-SingleNamespace --> oaa1(oaa1):::bad
    oaa1(oaa1):::bad --> oaa1(oaa1):::bad
  end

  t-oe:::tenant
  subgraph t-oe[oe]
  direction LR
  oe(oe):::im-SingleNamespace --> ne1[ne1]:::ns
  end

  t-occ:::tenant
  subgraph t-occ[occ]
  direction LR
  occ(occ):::im-SingleNamespace --> occ1(occ1):::im-SingleNamespace
    occ1(occ1):::im-SingleNamespace --> occ11(occ11):::bad
      occ11(occ11):::bad --> occ11(occ11):::bad
  end

  t-odd:::tenant
  subgraph t-odd[odd]
  direction LR
  odd(odd):::im-SingleNamespace --> odd1(odd1):::im-SingleNamespace
    odd1(odd1):::im-SingleNamespace --> odd11[odd11]:::ns
  end

  t-og:::tenant
  subgraph t-og[og]
  direction LR
  og(og):::im-MultiNamespace --> og1(og1):::im-MultiNamespace
    og1(og1):::im-MultiNamespace --> ng11[ng11]:::ns
    og1(og1):::im-MultiNamespace --> ng12[ng12]:::ns
  og(og):::im-MultiNamespace --> og2(og2):::im-MultiNamespace
    og2(og2):::im-MultiNamespace --> ng21[ng21]:::ns
    og2(og2):::im-MultiNamespace --> ng22[ng22]:::ns
  end

  t-ob:::tenant
  subgraph t-ob[ob]
  direction LR
  ob(ob):::im-MultiNamespace --> ob(ob):::im-MultiNamespace
    ob(ob):::im-MultiNamespace --> ob1(ob1):::im-OwnNamespace
      ob1(ob1):::im-OwnNamespace --> ob1(ob1):::im-OwnNamespace
  end

  t-of:::tenant
  subgraph t-of[of]
  direction LR
  of(of):::im-MultiNamespace --> nf1[nf1]:::ns
  of(of):::im-MultiNamespace --> nf2[nf2]:::ns
  end

  t-oh:::tenant
  subgraph t-oh[oh]
  direction LR
  oh(oh):::im-MultiNamespace --> oh1(oh1):::im-SingleNamespace
    oh1(oh1):::im-SingleNamespace --> nh11[nh11]:::ns
  oh(oh):::im-MultiNamespace --> th11[th11]:::ns
  end

  t-oaa:::tenant
  subgraph t-oaa[oaa]
  direction LR
  oaa(oaa):::im-SingleNamespace --> oaa1(oaa1):::bad
  end

  t-odd2:::tenant
  subgraph t-odd2[odd2]
  direction LR
  odd2(odd2):::im-SingleNamespace --> occ11(occ11):::bad
  end

  t-oa:::tenant
  subgraph t-oa[oa]
  direction LR
  oa(oa):::im-OwnNamespace --> oa(oa):::im-OwnNamespace
  end

  t-od:::tenant
  subgraph t-od[od]
  direction LR
  od(od):::im-MultiNamespace --> od(od):::im-MultiNamespace
    od(od):::im-MultiNamespace --> od1(od1):::im-MultiNamespace
      od1(od1):::im-MultiNamespace --> od1(od1):::im-MultiNamespace
        od1(od1):::im-MultiNamespace --> od11(od11):::im-OwnNamespace
          od11(od11):::im-OwnNamespace --> od11(od11):::im-OwnNamespace
        od1(od1):::im-MultiNamespace --> od12(od12):::im-OwnNamespace
          od12(od12):::im-OwnNamespace --> od12(od12):::im-OwnNamespace
    od(od):::im-MultiNamespace --> od2(od2):::im-MultiNamespace
      od2(od2):::im-MultiNamespace --> od2(od2):::im-MultiNamespace
        od2(od2):::im-MultiNamespace --> od21(od21):::im-OwnNamespace
          od21(od21):::im-OwnNamespace --> od21(od21):::im-OwnNamespace
        od2(od2):::im-MultiNamespace --> od22(od22):::im-OwnNamespace
          od22(od22):::im-OwnNamespace --> od22(od22):::im-OwnNamespace
  end

  t-openshift-operator-lifecycle-manager:::tenant
  subgraph t-openshift-operator-lifecycle-manager[openshift-operator-lifecycle-manager]
  direction LR
  openshift-operator-lifecycle-manager(openshift-operator-lifecycle-manager):::im-OwnNamespace --> openshift-operator-lifecycle-manager(openshift-operator-lifecycle-manager):::im-OwnNamespace
  end
```

