### PR TITLE
GH Actions CI and release improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,19 @@
 
-name: ci
+name: test
 on:
   push:
   pull_request:
 jobs:
-  goreleaser:
+  test:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
 
@@ -22,8 +22,3 @@ jobs:
 
     - name: Lint
       run: make lint
-
-    - name: Run GoReleaser
-      run: make release
-      env:
-        RELEASE_ARGS: release --rm-dist --snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,40 @@
 name: release
 on:
   push:
+    branches:
+    - 'main'
     tags:
     - 'v*.*.*'
+  pull_request:
+    branches:
+    - 'main'
+
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+
+    - name: Set the release related variables
+      if: startsWith(github.ref, 'refs/tags/v')
+      run: |
+        echo RELEASE_ARGS="--clean" >> $GITHUB_ENV
+        echo ENABLE_RELEASE_PIPELINE=true >> $GITHUB_ENV
 
     - name: Run GoReleaser
       run: make release
       env:
-        RELEASE_ARGS: release --rm-dist
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
 
     - name: Update new version in krew-index
-      uses: rajatjindal/krew-release-bot@v0.0.38
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,3 +36,6 @@ archives:
   format: tar.gz
   files:
   - LICENSE
+
+release:
+  disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,6 @@ lint:
 	source ./scripts/fetch.sh; fetch golangci-lint 1.50.1 && ./bin/golangci-lint --timeout 3m run
 
 .PHONY: release
-RELEASE_ARGS?=release --rm-dist --snapshot
+RELEASE_ARGS?=release --clean --snapshot
 release:
-	source ./scripts/fetch.sh; fetch goreleaser 1.13.0 && ./bin/goreleaser $(RELEASE_ARGS)
+	source ./scripts/fetch.sh; fetch goreleaser 1.22.1 && ./bin/goreleaser $(RELEASE_ARGS)

--- a/scripts/fetch.sh
+++ b/scripts/fetch.sh
@@ -3,6 +3,7 @@
 ROOT="$( git rev-parse --show-toplevel )"
 
 fetch() {
+  mkdir -p "${ROOT}/bin"
   local tool=$1; shift
   local ver=$1; shift
 


### PR DESCRIPTION
When we released v0.5.0, [the release action failed](https://github.com/operator-framework/kubectl-operator/actions/runs/6905779923/job/18789310542#step:5:10) because the `/bin` directory was not pre-created.

Something seems to have changed outside our repo to cause this to break, because this worked before. For now, let's just make sure we create this directory in advance of trying to untar into it.

While we're at it, also:
 - Bump versions of goreleaser and krew-release-bot
 - Share goreleaser workflow for PRs, branch pushes, and tags, but with configuration based on event type