### PR TITLE
✨  Add command to delete an existing olmv1 catalog

### DIFF
--- a/internal/cmd/internal/olmv1/catalog_delete.go
+++ b/internal/cmd/internal/olmv1/catalog_delete.go
@@ -1,0 +1,50 @@
+package olmv1
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/operator-framework/kubectl-operator/internal/cmd/internal/log"
+	v1action "github.com/operator-framework/kubectl-operator/internal/pkg/v1/action"
+	"github.com/operator-framework/kubectl-operator/pkg/action"
+)
+
+// NewCatalogDeleteCmd allows deleting either a single or all
+// existing catalogs
+func NewCatalogDeleteCmd(cfg *action.Configuration) *cobra.Command {
+	d := v1action.NewCatalogDelete(cfg)
+	d.Logf = log.Printf
+
+	cmd := &cobra.Command{
+		Use:     "catalog [catalog_name]",
+		Aliases: []string{"catalogs [catalog_name]"},
+		Args:    cobra.RangeArgs(0, 1),
+		Short:   "Delete either a single or all of the existing catalogs",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				catalogs, err := d.Run(cmd.Context())
+				if err != nil {
+					log.Fatalf("failed deleting catalogs: %v", err)
+				}
+				for _, catalog := range catalogs {
+					log.Printf("catalog %q deleted", catalog)
+				}
+
+				return
+			}
+
+			d.CatalogName = args[0]
+			if _, err := d.Run(cmd.Context()); err != nil {
+				log.Fatalf("failed to delete catalog %q: %v", d.CatalogName, err)
+			}
+			log.Printf("catalog %q deleted", d.CatalogName)
+		},
+	}
+	bindCatalogDeleteFlags(cmd.Flags(), d)
+
+	return cmd
+}
+
+func bindCatalogDeleteFlags(fs *pflag.FlagSet, d *v1action.CatalogDelete) {
+	fs.BoolVar(&d.DeleteAll, "all", false, "delete all catalogs")
+}

--- a/internal/cmd/olmv1.go
+++ b/internal/cmd/olmv1.go
@@ -31,11 +31,19 @@ func newOlmV1Cmd(cfg *action.Configuration) *cobra.Command {
 	}
 	createCmd.AddCommand(olmv1.NewCatalogCreateCmd(cfg))
 
+	deleteCmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a resource",
+		Long:  "Delete a resource",
+	}
+	deleteCmd.AddCommand(olmv1.NewCatalogDeleteCmd(cfg))
+
 	cmd.AddCommand(
 		olmv1.NewOperatorInstallCmd(cfg),
 		olmv1.NewOperatorUninstallCmd(cfg),
 		getCmd,
 		createCmd,
+		deleteCmd,
 	)
 
 	return cmd

--- a/internal/pkg/v1/action/action_suite_test.go
+++ b/internal/pkg/v1/action/action_suite_test.go
@@ -2,12 +2,16 @@ package action_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	olmv1catalogd "github.com/operator-framework/catalogd/api/v1"
 )
 
 func TestCommand(t *testing.T) {
@@ -43,4 +47,19 @@ type mockGetter struct {
 func (mg *mockGetter) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	mg.getCalled++
 	return mg.getErr
+}
+
+func setupTestCatalogs(n int) []client.Object {
+	var result []client.Object
+	for i := 1; i <= n; i++ {
+		result = append(result, newClusterCatalog(fmt.Sprintf("cat%d", i)))
+	}
+
+	return result
+}
+
+func newClusterCatalog(name string) *olmv1catalogd.ClusterCatalog {
+	return &olmv1catalogd.ClusterCatalog{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
 }

--- a/internal/pkg/v1/action/catalog_delete.go
+++ b/internal/pkg/v1/action/catalog_delete.go
@@ -1,0 +1,69 @@
+package action
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	olmv1catalogd "github.com/operator-framework/catalogd/api/v1"
+
+	"github.com/operator-framework/kubectl-operator/pkg/action"
+)
+
+type CatalogDelete struct {
+	config      *action.Configuration
+	CatalogName string
+	DeleteAll   bool
+
+	Logf func(string, ...interface{})
+}
+
+func NewCatalogDelete(cfg *action.Configuration) *CatalogDelete {
+	return &CatalogDelete{
+		config: cfg,
+		Logf:   func(string, ...interface{}) {},
+	}
+}
+
+func (cd *CatalogDelete) Run(ctx context.Context) ([]string, error) {
+	// validate
+	if cd.DeleteAll && cd.CatalogName != "" {
+		return nil, errNameAndSelector
+	}
+
+	// delete single, specified catalog
+	if !cd.DeleteAll {
+		return nil, cd.deleteCatalog(ctx, cd.CatalogName)
+	}
+
+	// delete all existing catalogs
+	var catatalogList olmv1catalogd.ClusterCatalogList
+	if err := cd.config.Client.List(ctx, &catatalogList); err != nil {
+		return nil, err
+	}
+	if len(catatalogList.Items) == 0 {
+		return nil, errNoResourcesFound
+	}
+
+	errs := make([]error, 0, len(catatalogList.Items))
+	names := make([]string, 0, len(catatalogList.Items))
+	for _, catalog := range catatalogList.Items {
+		names = append(names, catalog.Name)
+		if err := cd.deleteCatalog(ctx, catalog.Name); err != nil {
+			errs = append(errs, fmt.Errorf("failed deleting catalog %q: %w", catalog.Name, err))
+		}
+	}
+
+	return names, errors.Join(errs...)
+}
+
+func (cd *CatalogDelete) deleteCatalog(ctx context.Context, name string) error {
+	op := &olmv1catalogd.ClusterCatalog{}
+	op.SetName(name)
+
+	if err := cd.config.Client.Delete(ctx, op); err != nil {
+		return err
+	}
+
+	return waitForDeletion(ctx, cd.config.Client, op)
+}

--- a/internal/pkg/v1/action/catalog_delete_test.go
+++ b/internal/pkg/v1/action/catalog_delete_test.go
@@ -1,0 +1,110 @@
+package action_test
+
+import (
+	"context"
+	"slices"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	olmv1catalogd "github.com/operator-framework/catalogd/api/v1"
+
+	internalaction "github.com/operator-framework/kubectl-operator/internal/pkg/v1/action"
+	"github.com/operator-framework/kubectl-operator/pkg/action"
+)
+
+var _ = Describe("CatalogDelete", func() {
+	setupEnv := func(catalogs ...client.Object) action.Configuration {
+		var cfg action.Configuration
+
+		sch, err := action.NewScheme()
+		Expect(err).To(BeNil())
+
+		cl := fake.NewClientBuilder().
+			WithObjects(catalogs...).
+			WithScheme(sch).
+			Build()
+		cfg.Scheme = sch
+		cfg.Client = cl
+
+		return cfg
+	}
+
+	It("fails because of both resource name and --all specifier being present", func() {
+		cfg := setupEnv(setupTestCatalogs(2)...)
+
+		deleter := internalaction.NewCatalogDelete(&cfg)
+		deleter.CatalogName = "name"
+		deleter.DeleteAll = true
+		catNames, err := deleter.Run(context.TODO())
+		Expect(err).NotTo(BeNil())
+		Expect(catNames).To(BeEmpty())
+
+		validateExistingCatalogs(cfg.Client, []string{"cat1", "cat2"})
+	})
+
+	It("fails deleting a non-existing catalog", func() {
+		cfg := setupEnv(setupTestCatalogs(2)...)
+
+		deleter := internalaction.NewCatalogDelete(&cfg)
+		deleter.CatalogName = "does-not-exist"
+		catNames, err := deleter.Run(context.TODO())
+		Expect(err).NotTo(BeNil())
+		Expect(catNames).To(BeEmpty())
+
+		validateExistingCatalogs(cfg.Client, []string{"cat1", "cat2"})
+	})
+
+	It("successfully deletes an existing catalog", func() {
+		cfg := setupEnv(setupTestCatalogs(3)...)
+
+		deleter := internalaction.NewCatalogDelete(&cfg)
+		deleter.CatalogName = "cat2"
+		catNames, err := deleter.Run(context.TODO())
+		Expect(err).To(BeNil())
+		Expect(catNames).To(BeEmpty())
+
+		validateExistingCatalogs(cfg.Client, []string{"cat1", "cat3"})
+	})
+
+	It("fails deleting catalogs because there are none", func() {
+		cfg := setupEnv()
+
+		deleter := internalaction.NewCatalogDelete(&cfg)
+		deleter.DeleteAll = true
+		catNames, err := deleter.Run(context.TODO())
+		Expect(err).NotTo(BeNil())
+		Expect(catNames).To(BeEmpty())
+
+		validateExistingCatalogs(cfg.Client, []string{})
+	})
+
+	It("successfully deletes all catalogs", func() {
+		cfg := setupEnv(setupTestCatalogs(3)...)
+
+		deleter := internalaction.NewCatalogDelete(&cfg)
+		deleter.DeleteAll = true
+		catNames, err := deleter.Run(context.TODO())
+		Expect(err).To(BeNil())
+		Expect(catNames).To(ContainElements([]string{"cat1", "cat2", "cat3"}))
+
+		validateExistingCatalogs(cfg.Client, []string{})
+	})
+})
+
+func validateExistingCatalogs(c client.Client, wantedNames []string) {
+	var catalogsList olmv1catalogd.ClusterCatalogList
+	err := c.List(context.TODO(), &catalogsList)
+	Expect(err).To(BeNil())
+
+	catalogs := catalogsList.Items
+	Expect(catalogs).To(HaveLen(len(wantedNames)))
+	for _, wantedName := range wantedNames {
+		Expect(slices.ContainsFunc(catalogs, func(cat olmv1catalogd.ClusterCatalog) bool {
+			return cat.Name == wantedName
+		})).To(BeTrue())
+	}
+}

--- a/internal/pkg/v1/action/catalog_installed_get_test.go
+++ b/internal/pkg/v1/action/catalog_installed_get_test.go
@@ -2,13 +2,11 @@ package action_test
 
 import (
 	"context"
-	"fmt"
 	"slices"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -82,18 +80,3 @@ var _ = Describe("CatalogInstalledGet", func() {
 		Expect(operators).To(BeEmpty())
 	})
 })
-
-func setupTestCatalogs(n int) []client.Object {
-	var result []client.Object
-	for i := 1; i <= n; i++ {
-		result = append(result, newClusterCatalog(fmt.Sprintf("cat%d", i)))
-	}
-
-	return result
-}
-
-func newClusterCatalog(name string) *olmv1catalogd.ClusterCatalog {
-	return &olmv1catalogd.ClusterCatalog{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-	}
-}

--- a/internal/pkg/v1/action/errors.go
+++ b/internal/pkg/v1/action/errors.go
@@ -1,0 +1,8 @@
+package action
+
+import "errors"
+
+var (
+	errNoResourcesFound = errors.New("no resources found")
+	errNameAndSelector  = errors.New("name cannot be provided when a selector is specified")
+)

--- a/internal/pkg/v1/action/operator.go
+++ b/internal/pkg/v1/action/operator.go
@@ -1,9 +1,0 @@
-package action
-
-import (
-	"time"
-)
-
-const (
-	pollTimeout = 250 * time.Millisecond
-)

--- a/internal/pkg/v1/action/operator_uninstall.go
+++ b/internal/pkg/v1/action/operator_uninstall.go
@@ -7,8 +7,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	olmv1 "github.com/operator-framework/operator-controller/api/v1"
 
@@ -41,23 +39,4 @@ func (u *OperatorUninstall) Run(ctx context.Context) error {
 		return fmt.Errorf("delete %s %q: %v", lowerKind, op.GetName(), err)
 	}
 	return waitForDeletion(ctx, u.config.Client, op)
-}
-
-func waitForDeletion(ctx context.Context, cl client.Client, objs ...client.Object) error {
-	for _, obj := range objs {
-		obj := obj
-		lowerKind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
-		key := objectKeyForObject(obj)
-		if err := wait.PollUntilContextCancel(ctx, pollTimeout, true, func(conditionCtx context.Context) (bool, error) {
-			if err := cl.Get(conditionCtx, key, obj); apierrors.IsNotFound(err) {
-				return true, nil
-			} else if err != nil {
-				return false, err
-			}
-			return false, nil
-		}); err != nil {
-			return fmt.Errorf("wait for %s %q deleted: %v", lowerKind, key.Name, err)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
This adds `delete` command that enables deleting either a single or all existing catalogs (`ClusterCatalog`) from the cluster.

Signature:
```bash
Delete either a single or all of the existing catalogs

Usage:
  operator olmv1 delete catalog [catalog_name] [flags]

Aliases:
  catalog, catalogs [catalog_name]

Flags:
      --all    delete all catalogs
  -h, --help   help for catalog
```

Example walkthrough:
```bash
➜  kubectl get clustercatalogs
NAME            LASTUNPACKED   SERVING   AGE
operatorhubio   5m41s          True      5m51s
➜ go run *.go olmv1 delete catalog unknown
failed to delete catalog "unknown": clustercatalogs.olm.operatorframework.io "unknown" not found
exit status 1
➜ go run *.go olmv1 delete catalog operatorhubio
catalog "operatorhubio" deleted
➜ kubectl get clustercatalogs
No resources found

➜ kubectl get clustercatalogs
NAME             LASTUNPACKED   SERVING   AGE
operatorhubio    2m4s           True      2m11s
operatorhubio2   5s             True      18s
➜ go run *.go olmv1 delete catalog --all
catalog "operatorhubio" deleted
catalog "operatorhubio2" deleted
➜ kubectl get clustercatalogs
No resources found

➜ kubectl get clustercatalogs
NAME             LASTUNPACKED   SERVING   AGE
operatorhubio    55s            True      62s
operatorhubio2   45s            True      59s
➜ kubectl scale deploy catalogd-controller-manager operator-controller-controller-manager --replicas=0 -n olmv1-system
➜ go run *.go olmv1 delete catalog --all
failed deleting catalogs: failed deleting catalog "operatorhubio": waiting for deletion: context deadline exceeded
failed deleting catalog "operatorhubio2": client rate limiter Wait returned an error: context deadline exceeded
exit status 1

➜ kubectl get clustercatalogs
NAME             LASTUNPACKED   SERVING   AGE
operatorhubio2   23s            True      30s
➜ go run *.go olmv1 delete catalog operatorhubio2 --all
failed to delete catalog "operatorhubio2": name cannot be provided when a selector is specified
exit status 1
➜ go run *.go olmv1 delete catalog --all operatorhubio2
failed to delete catalog "operatorhubio2": name cannot be provided when a selector is specified
exit status 1
```

Additionally, does a light refactor of the old helpers, especially the `waitForDeletion`, which does not accept variable number of input objects anymore.
Benefits of this are:
* callers have more control over deletion and can decide how they want to run it - async/sync for example
* de-duplicated error messages - no need to mention details of the object within the helper
* no need for extending the deleting object with GVK info just for the sake of helper and its logging  

~There is some overlap with https://github.com/operator-framework/kubectl-operator/pull/218 - ie. test helpers, which will be cleaned up once that has been merged~ - done

Part of https://github.com/operator-framework/operator-controller/pull/1815 