### PR TITLE
fix empty client in action config

### DIFF
--- a/internal/cmd/internal/olmv1/catalog_create.go
+++ b/internal/cmd/internal/olmv1/catalog_create.go
@@ -13,7 +13,7 @@ import (
 
 // NewCatalogCreateCmd allows creating a new catalog
 func NewCatalogCreateCmd(cfg *action.Configuration) *cobra.Command {
-	i := v1action.NewCatalogCreate(cfg.Client)
+	i := v1action.NewCatalogCreate(cfg)
 	i.Logf = log.Printf
 
 	cmd := &cobra.Command{

--- a/internal/pkg/v1/action/helpers.go
+++ b/internal/pkg/v1/action/helpers.go
@@ -80,9 +80,8 @@ func deleteWithTimeout(cl deleter, obj client.Object, timeout time.Duration) err
 	return nil
 }
 
-func waitForDeletion(ctx context.Context, cl client.Client, objs ...client.Object) error {
+func waitForDeletion(ctx context.Context, cl getter, objs ...client.Object) error {
 	for _, obj := range objs {
-		obj := obj
 		lowerKind := strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind)
 		key := objectKeyForObject(obj)
 		if err := wait.PollUntilContextCancel(ctx, pollInterval, true, func(conditionCtx context.Context) (bool, error) {

--- a/internal/pkg/v1/action/interfaces.go
+++ b/internal/pkg/v1/action/interfaces.go
@@ -6,10 +6,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type creator interface {
-	Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
-}
-
 type deleter interface {
 	Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
 }

--- a/internal/pkg/v1/action/operator_update_test.go
+++ b/internal/pkg/v1/action/operator_update_test.go
@@ -145,8 +145,9 @@ var _ = Describe("OperatorUpdate", func() {
 		cfg := setupEnv(testExt, buildExtension("test2"), buildExtension("test3"))
 
 		go func() {
-			Eventually(updateOperatorConditionStatus("test", cfg.Client, olmv1.TypeInstalled, metav1.ConditionTrue)).
-				WithTimeout(5 * time.Second).WithPolling(200 * time.Second).
+			Eventually(updateOperatorConditionStatus).
+				WithArguments("test", cfg.Client, olmv1.TypeInstalled, metav1.ConditionTrue).
+				WithTimeout(5 * time.Second).WithPolling(200 * time.Millisecond).
 				Should(Succeed())
 		}()
 


### PR DESCRIPTION
Fixing the panic because of the empty client in action config
```
$ kubectl operator olmv1 create catalog operatorhub quay.io/operatorhubio/catalog:latest
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x184c59c]

goroutine 1 [running]:
github.com/operator-framework/kubectl-operator/internal/pkg/v1/action.(*CatalogCreate).Run(0xc0001126c0, {0x1f6f468, 0xc0002b19d0})
	kubectl-operator/internal/pkg/v1/action/catalog_create.go:41 +0x1dc
github.com/operator-framework/kubectl-operator/internal/cmd/internal/olmv1.NewCatalogCreateCmd.func1(0xc000374c08?, {0xc00030ed60?, 0x4?, 0x1c59745?})
	kubectl-operator/internal/cmd/internal/olmv1/catalog_create.go:28 +0xaf
github.com/spf13/cobra.(*Command).execute(0xc000374c08, {0xc00030ed20, 0x2, 0x2})
	/home/lmohanty/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0xc00040e908)
	/home/lmohanty/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/lmohanty/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/operator-framework/kubectl-operator/internal/cmd.Execute()
	kubectl-operator/internal/cmd/root.go:14 +0x18
main.main()
	kubectl-operator/main.go:8 +0xf
```

Also adding some nil value checks for printing clusterCatalogs and clusterExtensions. 